### PR TITLE
fix: pin version to last compatible pycryptodome version

### DIFF
--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,4 +1,4 @@
 cryptography<37
-pycryptodome>=3.10.1
+pycryptodome==3.19.0
 pytest
 git+https://github.com/c4dt/stem.git


### PR DESCRIPTION
fixes #17 